### PR TITLE
Add styled contact form to About page

### DIFF
--- a/about.html
+++ b/about.html
@@ -302,6 +302,46 @@ https://templatemo.com/tm-582-tale-seo-agency
     </div>
   </div>
 
+  <div class="contact-us section">
+    <div class="container">
+      <div class="row">
+        <div class="col-lg-8 offset-lg-2">
+          <div class="contact-us-content">
+            <form id="contact-form" action="#" method="post">
+              <div class="row">
+                <div class="col-lg-12">
+                  <div class="section-heading">
+                    <h2><em>Ponte en contacto</em></h2>
+                  </div>
+                </div>
+                <div class="col-lg-6">
+                  <fieldset>
+                    <input type="text" name="name" id="name" placeholder="Tu nombre..." autocomplete="on" required>
+                  </fieldset>
+                </div>
+                <div class="col-lg-6">
+                  <fieldset>
+                    <input type="email" name="email" id="email" pattern="[^ @]*@[^ @]*" placeholder="Tu correo electrónico..." required>
+                  </fieldset>
+                </div>
+                <div class="col-lg-12">
+                  <fieldset>
+                    <textarea name="message" id="message" placeholder="Tu mensaje" required></textarea>
+                  </fieldset>
+                </div>
+                <div class="col-lg-12">
+                  <fieldset>
+                    <button type="submit" id="form-submit" class="orange-button">Enviar mensaje</button>
+                  </fieldset>
+                </div>
+              </div>
+            </form>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+
   <footer>
     <div class="container">
       <div class="col-lg-12">


### PR DESCRIPTION
## Summary
- add centered contact form to about page using existing `contact-us` styles

## Testing
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68c496bdca4883259c060429f2b5d49a