### PR TITLE
Center FAQ content and streamline About page steps

### DIFF
--- a/about.html
+++ b/about.html
@@ -198,13 +198,12 @@ https://templatemo.com/tm-582-tale-seo-agency
                             <h4>Presenta tu idea al mundo</h4>
                             <div class="line-dec"></div>
                             <p>Nuestra plataforma te permite describir tu proyecto, fijar metas de recaudación y compartir documentación clave con los inversores.</p>
-                            <div class="info">
-                              <span>Resumen del proyecto</span>
-                              <span>Objetivos de financiación</span>
-                              <span>Presupuesto estimado</span>
-                              <span class="last-span">Canales de contacto</span>
-                            </div>
-                            <p>Cuanto más transparente seas, mayores serán las posibilidades de obtener el apoyo que necesitas.</p>
+                            <ul class="info-list">
+                              <li>Resumen del proyecto</li>
+                              <li>Objetivos de financiación</li>
+                              <li>Presupuesto estimado</li>
+                              <li>Canales de contacto</li>
+                            </ul>
                           </div>
                           <div class="col-lg-5 align-self-center">
                             <img src="assets/images/projects-01.jpg" alt="Inversionista satisfecho"/>
@@ -219,13 +218,12 @@ https://templatemo.com/tm-582-tale-seo-agency
                               <h4>Promociona tu campaña</h4>
                               <div class="line-dec"></div>
                               <p>Difunde tu proyecto entre tu comunidad y aprovecha nuestra red para alcanzar nuevos inversores.</p>
-                              <div class="info">
-                                <span>Difusión en redes</span>
-                                <span>Actualizaciones periódicas</span>
-                                <span>Retroalimentación</span>
-                                <span class="last-span">Credibilidad</span>
-                              </div>
-                              <p>Mantén informados a tus seguidores para generar confianza y participación.</p>
+                              <ul class="info-list">
+                                <li>Difusión en redes</li>
+                                <li>Actualizaciones periódicas</li>
+                                <li>Retroalimentación</li>
+                                <li>Credibilidad</li>
+                              </ul>
                             </div>
                             <div class="col-lg-5 align-self-center">
                               <img src="assets/images/projects-01.jpg" alt="Inversionista satisfecho"/>
@@ -240,13 +238,12 @@ https://templatemo.com/tm-582-tale-seo-agency
                               <h4>Gestiona la financiación</h4>
                               <div class="line-dec"></div>
                               <p>Cuando alcances tu objetivo, recibirás los fondos para llevar tu idea al siguiente nivel.</p>
-                              <div class="info">
-                                <span>Pagos seguros</span>
-                                <span>Contratos claros</span>
-                                <span>Uso responsable</span>
-                                <span class="last-span">Transparencia</span>
-                              </div>
-                              <p>Utiliza los recursos de acuerdo con tu plan y mantén informados a tus inversores.</p>
+                              <ul class="info-list">
+                                <li>Pagos seguros</li>
+                                <li>Contratos claros</li>
+                                <li>Uso responsable</li>
+                                <li>Transparencia</li>
+                              </ul>
 
                             </div>
                             <div class="col-lg-5 align-self-center">
@@ -263,13 +260,12 @@ https://templatemo.com/tm-582-tale-seo-agency
                               <h4>Comparte los resultados</h4>
                               <div class="line-dec"></div>
                               <p>Informa sobre los avances y el impacto generado. Los inversores valoran la comunicación abierta.</p>
-                              <div class="info">
-                                <span>Reportes periódicos</span>
-                                <span>Metas cumplidas</span>
-                                <span>Lecciones aprendidas</span>
-                                <span class="last-span">Nuevas rondas</span>
-                              </div>
-                              <p>Al demostrar resultados, tu comunidad estará lista para acompañarte en futuros proyectos.</p>
+                              <ul class="info-list">
+                                <li>Reportes periódicos</li>
+                                <li>Metas cumplidas</li>
+                                <li>Lecciones aprendidas</li>
+                                <li>Nuevas rondas</li>
+                              </ul>
                             </div>
                             <div class="col-lg-5 align-self-center">
                               <img src="assets/images/projects-01.jpg" alt="Inversionista satisfecho"/>

--- a/assets/css/templatemo-tale-seo-agency.css
+++ b/assets/css/templatemo-tale-seo-agency.css
@@ -2000,24 +2000,21 @@ Happy Clients Style
   margin-bottom: 25px;
 }
 
-.happy-clients ul.nacc li .info {
+.happy-clients ul.nacc li .info-list {
   margin-top: 30px;
   display: flex;
   flex-direction: column;
   gap: 15px;
+  padding-left: 0;
+  list-style: none;
 }
 
-.happy-clients ul.nacc li .info span {
-  display: block;
+.happy-clients ul.nacc li .info-list li {
   background-color: #253CF5;
   border-radius: 20px;
   color: #fff;
   padding: 10px 25px;
   font-size: 18px;
-}
-
-.happy-clients ul.nacc li .info span.last-span {
-  margin-right: 0px;
 }
 
 .happy-clients ul.nacc li.active {
@@ -2139,6 +2136,12 @@ Most Asked Style
 
 .most-asked .section-heading {
   margin-bottom: 80px;
+  text-align: center;
+}
+
+.most-asked .section-heading .line-dec {
+  margin-left: auto;
+  margin-right: auto;
 }
 
 .most-asked .accordions .accordion {

--- a/assets/js/custom.js
+++ b/assets/js/custom.js
@@ -115,22 +115,32 @@
 
 
 
-	$(document).on("click", ".naccs .menu div", function() {
-		var numberIndex = $(this).index();
-	
-		if (!$(this).is("active")) {
-			$(".naccs .menu div").removeClass("active");
-			$(".naccs ul li").removeClass("active");
-	
-			$(this).addClass("active");
-			$(".naccs ul").find("li:eq(" + numberIndex + ")").addClass("active");
-	
-			var listItemHeight = $(".naccs ul")
-				.find("li:eq(" + numberIndex + ")")
-				.innerHeight();
-			$(".naccs ul").height(listItemHeight + "px");
-		}
-	});
+        $(document).on("click", ".naccs .menu div", function() {
+                var numberIndex = $(this).index();
+
+                if (!$(this).is(".active")) {
+                        $(".naccs .menu div").removeClass("active");
+                        $(".naccs ul li").removeClass("active");
+
+                        $(this).addClass("active");
+                        $(".naccs ul").find("li:eq(" + numberIndex + ")").addClass("active");
+
+                        var listItemHeight = $(".naccs ul")
+                                .find("li:eq(" + numberIndex + ")")
+                                .outerHeight(true);
+                        $(".naccs ul").height(listItemHeight + "px");
+                }
+        });
+
+        $(function() {
+                var numberIndex = $(".naccs .menu div.active").index();
+                if (numberIndex >= 0) {
+                        var listItemHeight = $(".naccs ul")
+                                .find("li:eq(" + numberIndex + ")")
+                                .outerHeight(true);
+                        $(".naccs ul").height(listItemHeight + "px");
+                }
+        });
 
 
 	$('.owl-features').owlCarousel({

--- a/faqs.html
+++ b/faqs.html
@@ -185,7 +185,7 @@ https://templatemo.com/tm-582-tale-seo-agency
             </div>
         </div>
       </div>
-      <div class="row">
+      <div class="row justify-content-center">
         <div class="col-lg-6">
           <div class="accordions is-first-expanded">
               <article class="accordion">


### PR DESCRIPTION
## Summary
- Centered FAQ accordion block and heading for a balanced layout.
- Simplified About page steps so each tab shows a title, description, and four detail items with blue accents next to an image.
- Removed default bullet markers from About step lists for cleaner styling.
- Initialized About tab height and margin-aware sizing so the new menu details are visible.

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68c49ffb439c8325a5c10520d6a6441e