### PR TITLE
Style publish form for theme consistency

### DIFF
--- a/assets/css/templatemo-tale-seo-agency.css
+++ b/assets/css/templatemo-tale-seo-agency.css
@@ -2529,6 +2529,19 @@ Most Asked Style
   transform: translate(-50%, -50%) !important;
 }
 
+/* Flex layout for the publish form consent checkbox */
+#free-quote .checkbox-row {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+}
+
+/* Inline label inside the checkbox row */
+#free-quote .checkbox-row label {
+  display: inline;
+  margin-bottom: 0;
+}
+
 /* Contact section: icons and select styling */
 .contact-us .more-info .info-item i,
 .contact-us .info-item i {

--- a/publish.html
+++ b/publish.html
@@ -139,7 +139,7 @@
                 <div class="col-lg-6">
                   <fieldset>
                     <div class="file-control">
-                      <label class="file-title" style="font-weight:600;">Imagen destacada</label>
+                      <label class="file-title">Imagen destacada</label>
                       <div class="file-action">
                         <button type="button" class="custom-file-btn orange-button" data-target="featured_image_input">Seleccionar imagen</button>
                       </div>
@@ -153,7 +153,7 @@
                 <div class="col-lg-6">
                   <fieldset>
                     <div class="file-control">
-                      <label class="file-title" style="font-weight:600;">Documento / plan de negocio (PDF)</label>
+                      <label class="file-title">Documento / plan de negocio (PDF)</label>
                       <div class="file-action">
                         <button type="button" class="custom-file-btn orange-button" data-target="business_doc_input">Subir PDF</button>
                       </div>
@@ -167,7 +167,7 @@
 
                 <div class="col-lg-12">
                   <fieldset>
-                    <label style="font-weight:600;">Información financiera y métricas clave</label>
+                    <label>Información financiera y métricas clave</label>
                     <textarea name="financials" id="financials" placeholder="Ingresos proyectados, costes, margen, uso de fondos, etc." required></textarea>
                   </fieldset>
                 </div>
@@ -175,7 +175,7 @@
                 <div class="col-lg-12">
                   <fieldset>
                     
-                    <div class="checkbox-row" style="display:flex; align-items:center; gap:12px;">
+                    <div class="checkbox-row">
                       <input class="form-check-input" type="checkbox" id="agree" name="agree" required>
                       <label for="agree">Certifico que la información es verídica y autorizo la revisión por parte de InVestingD.</label>
                     </div>


### PR DESCRIPTION
## Summary
- Remove inline styles from publish form and rely on theme classes
- Add CSS for consent checkbox layout to match existing form styling

## Testing
- `npm test` *(fails: could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68c4b54bb35883258168868ddcc8b242