### PR TITLE
Update about page progress bar color to orange

### DIFF
--- a/assets/css/templatemo-tale-seo-agency.css
+++ b/assets/css/templatemo-tale-seo-agency.css
@@ -1839,7 +1839,7 @@ Infos Style
 .video-info .skill-slide {
   position: relative;
   width: 100%;
-  background-color: rgba(37,60,245,0.06);
+  background-color: rgba(255,165,0,0.06);
   height: 10px;
   border-radius: 5px;
   margin-bottom: 60px;
@@ -1847,7 +1847,7 @@ Infos Style
 
 .video-info .skill-slide .fill {
   height: 10px;
-  background-color: #253CF5;
+  background-color: #FFA500;
   border-radius: 5px;
 }
 


### PR DESCRIPTION
## Summary
- restyle progress bars on about page to use orange fill and track hues

## Testing
- `npm test` *(fails: enoent package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68c4b69feb708325b13cc1f785956ee0