### PR TITLE
Estilizar páginas de envío en blockchain

### DIFF
--- a/blockchain/actualizar.html
+++ b/blockchain/actualizar.html
@@ -1,0 +1,55 @@
+<!DOCTYPE html>
+<html lang="es">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>Actualización del estado - PasarEx Colombia</title>
+  <link href="https://fonts.googleapis.com/css2?family=Open+Sans:wght@300;400;600;700&display=swap" rel="stylesheet" />
+  <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/css/bootstrap.min.css" rel="stylesheet" />
+  <link href="style.css" rel="stylesheet" />
+</head>
+<body>
+  <nav class="navbar navbar-expand-lg navbar-light bg-light shadow-sm">
+    <div class="container">
+      <a class="navbar-brand" href="index.html">PasarEx Colombia</a>
+      <button class="navbar-toggler" type="button" data-bs-toggle="collapse" data-bs-target="#navbarNav" aria-controls="navbarNav" aria-expanded="false" aria-label="Toggle navigation">
+        <span class="navbar-toggler-icon"></span>
+      </button>
+      <div class="collapse navbar-collapse" id="navbarNav">
+        <ul class="navbar-nav ms-auto">
+          <li class="nav-item"><a class="nav-link" href="registrar.html">Registrar envío</a></li>
+          <li class="nav-item"><a class="nav-link" href="actualizar.html">Actualización del estado</a></li>
+          <li class="nav-item"><a class="nav-link" href="verificar.html">Verificar envío</a></li>
+        </ul>
+      </div>
+    </div>
+  </nav>
+  <section class="main">
+    <div class="container">
+      <div class="row justify-content-center">
+        <div class="col-lg-8">
+          <div class="form-container">
+            <h1>Actualización del estado</h1>
+            <form>
+              <div class="mb-3">
+                <label for="ciudad-destino" class="form-label">Ciudad destino</label>
+                <input type="text" class="form-control" id="ciudad-destino" required />
+              </div>
+              <div class="mb-3">
+                <label for="ciudad-actual" class="form-label">Ciudad actual</label>
+                <input type="text" class="form-control" id="ciudad-actual" required />
+              </div>
+              <div class="mb-3">
+                <label for="estado" class="form-label">Estado</label>
+                <input type="text" class="form-control" id="estado" required />
+              </div>
+              <button type="submit" class="btn btn-primary">Actualizar</button>
+            </form>
+          </div>
+        </div>
+      </div>
+    </div>
+  </section>
+  <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/js/bootstrap.bundle.min.js"></script>
+</body>
+</html>

--- a/blockchain/index.html
+++ b/blockchain/index.html
@@ -1,0 +1,45 @@
+<!DOCTYPE html>
+<html lang="es">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>PasarEx Colombia</title>
+  <link href="https://fonts.googleapis.com/css2?family=Open+Sans:wght@300;400;600;700&display=swap" rel="stylesheet" />
+  <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/css/bootstrap.min.css" rel="stylesheet" />
+  <link href="style.css" rel="stylesheet" />
+</head>
+<body>
+  <nav class="navbar navbar-expand-lg navbar-light bg-light shadow-sm">
+    <div class="container">
+      <a class="navbar-brand" href="index.html">PasarEx Colombia</a>
+      <button class="navbar-toggler" type="button" data-bs-toggle="collapse" data-bs-target="#navbarNav" aria-controls="navbarNav" aria-expanded="false" aria-label="Toggle navigation">
+        <span class="navbar-toggler-icon"></span>
+      </button>
+      <div class="collapse navbar-collapse" id="navbarNav">
+        <ul class="navbar-nav ms-auto">
+          <li class="nav-item"><a class="nav-link" href="registrar.html">Registrar envío</a></li>
+          <li class="nav-item"><a class="nav-link" href="actualizar.html">Actualización del estado</a></li>
+          <li class="nav-item"><a class="nav-link" href="verificar.html">Verificar envío</a></li>
+        </ul>
+      </div>
+    </div>
+  </nav>
+
+  <section class="hero">
+    <div class="container">
+      <h1>Eficiencia y confiabilidad en cada envío con PasarEx</h1>
+      <p>Ingresa el número de guía para rastrear tu envío en tiempo real.</p>
+      <form class="row justify-content-center mt-4">
+        <div class="col-md-4 col-sm-6 mb-3">
+          <input type="text" class="form-control" placeholder="Número de guía" />
+        </div>
+        <div class="col-auto mb-3">
+          <button type="submit" class="btn btn-primary">Rastrear envío</button>
+        </div>
+      </form>
+    </div>
+  </section>
+
+  <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/js/bootstrap.bundle.min.js"></script>
+</body>
+</html>

--- a/blockchain/registrar.html
+++ b/blockchain/registrar.html
@@ -1,0 +1,67 @@
+<!DOCTYPE html>
+<html lang="es">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>Registrar envío - PasarEx Colombia</title>
+  <link href="https://fonts.googleapis.com/css2?family=Open+Sans:wght@300;400;600;700&display=swap" rel="stylesheet" />
+  <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/css/bootstrap.min.css" rel="stylesheet" />
+  <link href="style.css" rel="stylesheet" />
+</head>
+<body>
+  <nav class="navbar navbar-expand-lg navbar-light bg-light shadow-sm">
+    <div class="container">
+      <a class="navbar-brand" href="index.html">PasarEx Colombia</a>
+      <button class="navbar-toggler" type="button" data-bs-toggle="collapse" data-bs-target="#navbarNav" aria-controls="navbarNav" aria-expanded="false" aria-label="Toggle navigation">
+        <span class="navbar-toggler-icon"></span>
+      </button>
+      <div class="collapse navbar-collapse" id="navbarNav">
+        <ul class="navbar-nav ms-auto">
+          <li class="nav-item"><a class="nav-link" href="registrar.html">Registrar envío</a></li>
+          <li class="nav-item"><a class="nav-link" href="actualizar.html">Actualización del estado</a></li>
+          <li class="nav-item"><a class="nav-link" href="verificar.html">Verificar envío</a></li>
+        </ul>
+      </div>
+    </div>
+  </nav>
+  <section class="main">
+    <div class="container">
+      <div class="row justify-content-center">
+        <div class="col-lg-8">
+          <div class="form-container">
+            <h1>Registrar envío</h1>
+            <form>
+              <div class="mb-3">
+                <label for="destinatario" class="form-label">Destinatario</label>
+                <input type="text" class="form-control" id="destinatario" required />
+              </div>
+              <div class="mb-3">
+                <label for="destino" class="form-label">Destino</label>
+                <input type="text" class="form-control" id="destino" required />
+              </div>
+              <div class="mb-3">
+                <label for="valor" class="form-label">Valor de la mercancía</label>
+                <input type="number" class="form-control" id="valor" required />
+              </div>
+              <div class="mb-3">
+                <label for="descripcion" class="form-label">Descripción</label>
+                <textarea class="form-control" id="descripcion" required></textarea>
+              </div>
+              <div class="mb-3">
+                <label for="dimension" class="form-label">Dimensión del paquete</label>
+                <input type="text" class="form-control" id="dimension" required />
+              </div>
+              <div class="mb-3">
+                <label for="peso" class="form-label">Peso</label>
+                <input type="number" step="0.01" class="form-control" id="peso" required />
+              </div>
+              <button type="submit" class="btn btn-primary">Registrar</button>
+            </form>
+          </div>
+        </div>
+      </div>
+    </div>
+  </section>
+  <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/js/bootstrap.bundle.min.js"></script>
+</body>
+</html>

--- a/blockchain/style.css
+++ b/blockchain/style.css
@@ -1,0 +1,75 @@
+body {
+  font-family: 'Open Sans', sans-serif;
+  background-color: #f5f6fa;
+  min-height: 100vh;
+  color: #333;
+}
+
+/* Sección principal con imagen de fondo al estilo PasarEx */
+.hero {
+  background: linear-gradient(rgba(0, 78, 146, 0.75), rgba(0, 4, 40, 0.85)),
+    url('../assets/images/inicio.jpg') center/cover no-repeat;
+  min-height: 80vh;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  text-align: center;
+}
+
+.hero h1 {
+  color: #fff;
+  font-weight: 600;
+}
+
+.hero p {
+  color: #f0f4fa;
+  font-size: 1.1rem;
+}
+
+.main {
+  padding-top: 80px;
+  padding-bottom: 40px;
+}
+
+.form-container {
+  background-color: #ffffff;
+  padding: 2rem;
+  border-radius: 8px;
+  box-shadow: 0 4px 20px rgba(0, 0, 0, 0.1);
+}
+
+.form-container label {
+  color: #004e92;
+  font-weight: 600;
+}
+
+.form-container .form-control {
+  color: #333;
+}
+
+.navbar-brand {
+  font-weight: 600;
+  color: #004e92 !important;
+}
+
+.navbar-light .navbar-nav .nav-link {
+  color: #004e92;
+}
+
+.btn-primary {
+  background-color: #004e92;
+  border-color: #004e92;
+}
+
+.btn-primary:hover {
+  background-color: #003f7f;
+  border-color: #003f7f;
+}
+
+h1, h2, h3, h4, h5, h6 {
+  color: #004e92;
+}
+
+.text-white {
+  color: #fff !important;
+}

--- a/blockchain/verificar.html
+++ b/blockchain/verificar.html
@@ -1,0 +1,51 @@
+<!DOCTYPE html>
+<html lang="es">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>Verificar envío - PasarEx Colombia</title>
+  <link href="https://fonts.googleapis.com/css2?family=Open+Sans:wght@300;400;600;700&display=swap" rel="stylesheet" />
+  <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/css/bootstrap.min.css" rel="stylesheet" />
+  <link href="style.css" rel="stylesheet" />
+</head>
+<body>
+  <nav class="navbar navbar-expand-lg navbar-light bg-light shadow-sm">
+    <div class="container">
+      <a class="navbar-brand" href="index.html">PasarEx Colombia</a>
+      <button class="navbar-toggler" type="button" data-bs-toggle="collapse" data-bs-target="#navbarNav" aria-controls="navbarNav" aria-expanded="false" aria-label="Toggle navigation">
+        <span class="navbar-toggler-icon"></span>
+      </button>
+      <div class="collapse navbar-collapse" id="navbarNav">
+        <ul class="navbar-nav ms-auto">
+          <li class="nav-item"><a class="nav-link" href="registrar.html">Registrar envío</a></li>
+          <li class="nav-item"><a class="nav-link" href="actualizar.html">Actualización del estado</a></li>
+          <li class="nav-item"><a class="nav-link" href="verificar.html">Verificar envío</a></li>
+        </ul>
+      </div>
+    </div>
+  </nav>
+  <section class="main">
+    <div class="container">
+      <div class="row justify-content-center">
+        <div class="col-lg-8">
+          <div class="form-container">
+            <h1>Verificar envío</h1>
+            <form>
+              <div class="mb-3">
+                <label for="valor-pagado" class="form-label">Valor pagado</label>
+                <input type="number" class="form-control" id="valor-pagado" required />
+              </div>
+              <div class="mb-3">
+                <label for="estado-paquete" class="form-label">Estado del paquete</label>
+                <input type="text" class="form-control" id="estado-paquete" required />
+              </div>
+              <button type="submit" class="btn btn-primary">Verificar</button>
+            </form>
+          </div>
+        </div>
+      </div>
+    </div>
+  </section>
+  <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/js/bootstrap.bundle.min.js"></script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- Crear sección de inicio con imagen de fondo y formulario de rastreo inspirado en PasarEx
- Ajustar estilos de formularios y etiquetas para mejorar legibilidad
- Usar Bootstrap 5 desde CDN para evitar que se oculten los textos y refinar la navegación

## Testing
- `npm test` (fails: Missing script "test")


------
https://chatgpt.com/codex/tasks/task_e_68c58ce2439c8325bfcf81bf656caa00