### PR TITLE
Align services section with main banner layout

### DIFF
--- a/assets/css/templatemo-tale-seo-agency.css
+++ b/assets/css/templatemo-tale-seo-agency.css
@@ -1299,14 +1299,13 @@ Services Style
   padding-right: 30px;
 }
 
-.services::before {
-  content: url(../images/services-left.jpg);
-  top: 120px;
-  left: 0;
-  position: absolute;
-  width: 844px;
-  height: 714px;
-  z-index: -1;
+.services-left-image {
+  width: 100%;
+  height: auto;
+  max-height: 520px;
+  object-fit: contain;
+  border-radius: 12px;
+  box-shadow: 0 10px 30px rgba(0,0,0,0.12);
 }
 
 .services::after {
@@ -2708,14 +2707,6 @@ body {
     border-right: none;
   }
 }
-
-@media (max-width: 1200px) {
-  .services::before {
-    top: 60%;
-    transform: translateY(-50%);
-  }
-}
-
 @media (max-width: 1400px) {
   .main-banner .caption {
     background-color: rgba(250, 250, 250, 0.95);

--- a/index.html
+++ b/index.html
@@ -134,7 +134,10 @@ https://templatemo.com/tm-582-tale-seo-agency
   <div class="services section" id="services">
     <div class="container">
       <div class="row">
-        <div class="col-lg-6 offset-lg-6">
+        <div class="col-lg-5 align-self-center">
+          <img src="assets/images/inicio.jpg" alt="Inversionistas analizando oportunidades" class="services-left-image">
+        </div>
+        <div class="col-lg-7 align-self-center">
           <div class="row">
             <div class="col-lg-12">
               <div class="section-heading">


### PR DESCRIPTION
## Summary
- restructure "Proyectos Destacados & Oportunidades" section to mirror main banner with image left and content right
- remove pseudo-element background and add styled `services-left-image` class

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68c735cf924883259b64fe64eec2e3c4